### PR TITLE
use fuji deployer on fuji-fork. same for mainnet

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -219,7 +219,10 @@ module.exports = {
   namedAccounts: {
     deployerAddr: {
       default: 0,
-      localhost: addresses.mainnet.Guardian,
+      localhost:
+        (process.env.FORK === "mainnet" && addresses.mainnet.Deployer) ||
+        (process.env.FORK === "fuji" && addresses.fuji.Deployer) ||
+        0,
       "fuji-prod": addresses.fuji.Deployer,
       "mainnet-prod": addresses.mainnet.Deployer,
     },


### PR DESCRIPTION
If you made a contract change, make sure to complete the checklist below before merging it in master.

Refer to our [documentation](https://github.com/OriginProtocol/security) for more details about contract security best practices.


Contract change checklist:
  - [x] Code reviewed by 1 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).

  - [x] Unit tests pass – yarn test
  - [x] Smoke tests pass: cd contracts && ./scripts/smokeTest.sh
  - [x] Slither tests pass with no warning
  - [x] Echidna tests pass if PR includes changes to XUSD contract (not automated, run manually on local)


Change behavior for forks: use fuji or mainnet deployers. Fixes bug: fuji forks used mainnet deployer address, which was only revealed after changing mainnet address in #39 
